### PR TITLE
Restyle Header Navigation and Breadcrumbs

### DIFF
--- a/bakerydemo/static/css/main.css
+++ b/bakerydemo/static/css/main.css
@@ -367,15 +367,15 @@ cite {
   }
 }
 
+.navigation__items > li {
+  padding: 10px 0;
+}
+
 .navigation__items > li > a {
   color: var(--dark);
   font-family: var(--font--secondary);
   font-size: 18px;
   line-height: 28px;
-  padding: 10px 0;
-}
-
-.navigation__items > li {
   padding: 10px 0;
 }
 
@@ -387,6 +387,7 @@ cite {
   .navigation__items > li {
     padding: 0 0 0 20px;
   }
+
   .navigation__items > li > a {
     padding: 10px;
   }

--- a/bakerydemo/static/css/main.css
+++ b/bakerydemo/static/css/main.css
@@ -401,9 +401,10 @@ cite {
 .navigation__items > li.active > a,
 .navigation__items > li.active > a:focus,
 .navigation__items > li.active > a:hover {
-  background-color: var(--cream);
   color: var(--black);
   border-radius: 0;
+  border-bottom: 4px solid var(--orange);
+  background-color: transparent;
 }
 
 .navigation__items > li:hover,
@@ -562,41 +563,43 @@ li.has-submenu a.allow-toggle {
 
 /* Breadcrumbs */
 .breadcrumb-container {
-  background: linear-gradient(
-    to right,
-    rgba(21, 38, 44, 0.8) 0%,
-    rgba(0, 0, 0, 0.9) 100%
-  );
-  margin-top: -1px;
   position: relative;
   z-index: 3;
 }
 
 .breadcrumb {
-  background-color: transparent;
-  color: #ccc;
+  color: var(--dark);
   font-family: var(--font--secondary);
-  font-size: 14px;
+  font-size: 16px;
+  line-height: 24px;
   margin-bottom: 0px;
   padding-left: 0px;
+  text-decoration: underline;
+  background-color: transparent;
+}
+
+.breadcrumb>li+li:before {
+  display: none;
+}
+
+.breadcrumb__chevron-icon {
+  width: 8px;
+  height: 16px;
+  margin: 0 10px;
+}
+
+.breadcrumb__chevron-icon path {
+  fill: var(--dark);
 }
 
 .breadcrumb a,
 .breadcrumb .active {
-  color: #ccc;
-}
-
-.breadcrumb .active {
-  font-weight: bold;
+  color: var(--black);
+  text-decoration: underline;
 }
 
 .breadcrumb a:hover {
-  color: #fff;
-  text-decoration: none;
-}
-
-.breadcrumb > li + li:before {
-  content: "\00BB";
+  color: var(--dark-orange);
 }
 
 /* Pagination navigation */

--- a/bakerydemo/static/css/main.css
+++ b/bakerydemo/static/css/main.css
@@ -21,7 +21,7 @@
   --grey: #6e6e6e;
   --border-grey: #E1DCD3;
   --white: #ffffff;
-  --cream: #f5f3f9;
+  --cream: #f5f3e9;
   --light-brown: #87744f;
   --mid-brown: #825600;
   --dark-brown: #553801;
@@ -180,14 +180,6 @@ a.btn-sm {
   padding: 6px 8px;
 }
 
-.header input {
-  border-radius: 3px;
-  border: none;
-  font-size: 18px;
-  padding: 10px;
-  width: 100%;
-}
-
 ul {
   margin: 0 0 30px;
 }
@@ -316,186 +308,196 @@ cite {
 /* Page header */
 
 .header {
-  padding: 15px 0 15px;
+  padding: 0;
   width: 100%;
-  background: rgb(25, 17, 18);
-  background: linear-gradient(
-    135deg,
-    rgba(25, 17, 18, 1) 0%,
-    rgba(55, 28, 25, 1) 100%
-  );
+  background: var(--white);
   z-index: 10;
 }
 
-.header h3 {
-  margin-top: 0;
-  margin-bottom: 0;
-  line-height: 40px;
+
+/* Main menu */
+.navigation {
+  display: flex;
+  flex-wrap: wrap;
+  flex-direction: row;
+  align-items: center;
+  padding: 25px 0;
 }
 
-/* Logo */
-.logo,
-.logo:visited,
-.logo:focus {
-  display: inline-block;
-  padding: 0;
-  color: white;
-  font-size: 30px;
-  font-weight: 300;
-  margin: 0 0 0;
-}
-
-.logo:hover {
-  color: #d4566b;
-  text-decoration: none;
-}
-
-.search {
+.navigation__search {
   display: none;
   margin: 15px 0 0 0;
   position: relative;
 }
 
-@media (min-width: 768px) {
-  .search {
-    float: right;
-    margin: 0 0 0 30px;
+.navigation__search-icon {
+  display: block;
+  position: absolute;
+  right: 13px;
+  top: 11px;
+}
+
+.navigation__search-input {
+  color: var(--dark);
+  font-size: 16px;
+  line-height: 24px;
+  border: 1px solid var(--dark);
+  padding: 10px;
+}
+
+.navigation__items {
+  display: none;
+  list-style: none;
+  margin: 0;
+  padding: 20px 0 0 0;
+}
+
+@media (min-width: 1150px) {
+  .navigation {
+    flex-wrap: nowrap;
+  }
+
+  .navigation__search {
+    display: block;
+    margin: 0 0 0 auto;
+  }
+
+  .navigation__items {
+    padding: 0 0 0 20px;
   }
 }
 
-.search-icon {
-  display: block;
-  display: inline-block;
-  height: 20px;
-  position: absolute;
-  right: 10px;
-  top: 10px;
-  width: 20px;
+.navigation__items > li > a {
+  color: var(--dark);
+  font-family: var(--font--secondary);
+  font-size: 18px;
+  line-height: 28px;
+  padding: 10px 0;
 }
 
-.search-icon svg {
-  fill: #d4566b;
-  height: 20px;
-  width: 20px;
+.navigation__items > li {
+  padding: 10px 0;
 }
 
-/* Main menu */
-nav {
-  margin: 15px 0 5px;
-  display: none;
+@media (min-width: 1150px) {
+  .navigation__items {
+    display: block;
+  }
+
+  .navigation__items > li {
+    padding: 0 0 0 20px;
+  }
+  .navigation__items > li > a {
+    padding: 10px;
+  }
+
+  .navigation__items > li:first-child {
+    padding: 0;
+  }
 }
 
-#main-navigation {
-  padding-left: 0;
+/* N.B. We're overriding Bootstrap's default nav styles here, 
+   these rules set what the currently active nav tab looks like. */
+.navigation__items > li.active > a,
+.navigation__items > li.active > a:focus,
+.navigation__items > li.active > a:hover {
+  background-color: var(--cream);
+  color: var(--black);
+  border-radius: 0;
 }
 
+.navigation__items > li:hover,
+.navigation__items > li > a:focus,
+.navigation__items > li > a:hover {
+  text-decoration: underline;
+}
+
+.navigation__mobile-toggle {
+  margin: 0 0 0 auto;
+}
+
+/* Required as bootstrap nav automatically hides this otherwise */
 @media (min-width: 768px) {
-  nav {
-    margin: 15px 0 0 0;
-    border-top: 1px solid rgba(255, 255, 255, 0.1);
+  .navigation__mobile-toggle {
     display: block;
   }
 }
 
-.nav-pills > li + li {
-  margin-left: 0;
-}
-
-.nav-pills > li > a {
-  border-radius: 0;
-  border-top: 1px solid transparent;
-  color: white;
-  font-family: var(--font--secondary);
-  font-size: 11px;
-  font-weight: 300;
-  letter-spacing: 0.15em;
-  margin-top: -1px;
-  padding: 10px 10px;
-  text-transform: uppercase;
-}
-
-@media (min-width: 768px) {
-  .nav-pills > li > a {
-    padding: 10px 20px;
-    font-size: 14px;
+@media (min-width: 1150px) {
+  .navigation__mobile-toggle {
+    display: none;
   }
 }
 
-.nav-pills > li > a,
-.nav-pills > li > a:focus,
-.nav-pills > li > a:hover,
-.nav-pills > li,
-.nav-pills > li,
-.nav > li > a,
-.nav > li > a {
-  border-top: 1px solid transparent;
+
+.navigation__toggle-icon-bar {
+  background-color: var(--dark);
+  width: 30px;
+  height: 2px;
+  margin-bottom: 8px;
+  display: block;
 }
 
-/* The following is to stop a pixel shift on hover */
-.nav-pills > .breads {
-  width: 90px;
+.navigation__toggle-icon-bar:last-child {
+  margin-bottom: 0;
 }
 
-.nav-pills > .locations {
-  width: 140px;
+.collapse.in {
+  padding: 0;
 }
 
-.nav-pills > .blog {
-  width: 86px;
+@media (max-width: 1150px) {
+  .collapse.in {
+    flex-basis: 100%;
+    overflow-y: hidden;
+  }
+
+  .collapse.in .navigation__items {
+    display: block;
+  }
 }
 
-.nav-pills > .gallery {
-  width: 115px;
-}
-
-.nav-pills > .contactus {
-  width: 148px;
-}
-
-.nav-pills > .about {
-  width: 88px;
-}
-
-.nav-pills > li.active > a,
-.nav-pills > li.active > a:focus,
-.nav-pills > li.active > a:hover,
-.nav-pills > li.active,
-.nav-pills > li:hover,
-.nav > li > a:focus,
-.nav > li > a:hover {
-  color: #d4566b;
-  background-color: transparent;
-  border-top: 1px solid #d4566b;
+.navigation__logo,
+.navigation__logo:visited,
+.navigation__logo:focus {
+  display: inline-block;
+  color: var(--dark);
+  font-family: var(--font--primary);
   font-weight: 400;
+  font-size: 24px;
+  line-height: 30px;
+  margin: 0 0 0;
+  position: relative;
 }
 
-.nav-pills > li:first-of-type > a {
-  padding-left: 0;
-}
-
-.nav .open > a,
-.nav .open > a:focus,
-.nav .open > a:hover {
-  background-color: transparent;
-  border-top: 1px solid #d4566b;
+@media (min-width: 1150px) {
+  .navigation__logo::after {
+    content: '';
+    position: absolute;
+    right: -20px;
+    top: -5px;
+    bottom: 0;
+    width: 1px;
+    height: 42px;
+    background-color: var(--border-grey);
+  }
 }
 
 .dropdown-menu {
-  background-color: rgba(25, 17, 18, 1);
+  background-color: var(--cream);
   border-radius: 0;
   border: transparent;
 }
 
 .dropdown-menu > li > a {
-  border-bottom: 1px solid #371c19;
-  color: #fff;
+  border-bottom: 1px solid var(--border-grey);
+  color: var(--dark);
   font-family: var(--font--secondary);
   padding: 10px 20px;
 }
 
 .dropdown-menu > li > a:hover {
-  background-color: transparent;
-  color: #d4566b;
+  text-decoration: underline;
 }
 
 /* Menu dropdown hack to allow toggling */
@@ -514,23 +516,10 @@ li.has-submenu a.allow-toggle {
 }
 
 /* Mobile menu styling */
-@media (max-width: 768px) {
+@media (max-width: 1150px) {
   .nav-pills > .presentation {
     float: none;
     width: 100%;
-  }
-
-  .nav-pills > li > a {
-    border-top: 1px solid rgba(255, 255, 255, 0.1);
-    padding: 20px 0;
-  }
-
-  li.has-submenu a.allow-toggle {
-    float: none;
-  }
-
-  li.has-submenu a.caret-custom {
-    display: none !important;
   }
 }
 
@@ -608,11 +597,6 @@ li.has-submenu a.allow-toggle {
 
 .breadcrumb > li + li:before {
   content: "\00BB";
-}
-
-/* Mobile nav */
-.navbar-toggle .icon-bar {
-  background-color: #fff;
 }
 
 /* Pagination navigation */

--- a/bakerydemo/templates/includes/header.html
+++ b/bakerydemo/templates/includes/header.html
@@ -5,7 +5,8 @@
         <div class="navigation">
             <a href="/" class="navigation__logo">The Wagtail Bakery</a>
 
-            <button type="button" class="navigation__mobile-toggle navbar-toggle collapsed" data-toggle="collapse" data-target="#main-navigation" aria-label="Mobile menu" aria-expanded="false">
+            <button type="button" class="navigation__mobile-toggle navbar-toggle collapsed" data-toggle="collapse"
+                data-target="#main-navigation" aria-label="Mobile menu" aria-expanded="false">
                 <span class="sr-only">Toggle navigation</span>
                 <span class="navigation__toggle-icon-bar"></span>
                 <span class="navigation__toggle-icon-bar"></span>
@@ -13,20 +14,25 @@
             </button>
 
             {% block main_navigation %}
-                <nav class="collapse navbar-collapse" id="main-navigation" role="navigation" aria-label="Primary site navigation">
-                    <ul class="navigation__items nav-pills">
-                        {# main_menu is defined in base/templatetags/navigation_tags.py #}
-                        {% get_site_root as site_root %}
-                        {% top_menu parent=site_root calling_page=self %}
-                    </ul>
-                </nav>
+            <nav class="collapse navbar-collapse" id="main-navigation" role="navigation"
+                aria-label="Primary site navigation">
+                <ul class="navigation__items nav-pills">
+                    {# main_menu is defined in base/templatetags/navigation_tags.py #}
+                    {% get_site_root as site_root %}
+                    {% top_menu parent=site_root calling_page=self %}
+                </ul>
+            </nav>
             {% endblock %}
 
             <form action="/search" method="get" class="navigation__search" role="search">
-                <input class="navigation__search-input" name="q" type="text" placeholder="Search" aria-label="Search the bakery" autocomplete="off">
+                <label for="search-input" class="u-sr-only">Search this site</label>
+                <input class="navigation__search-input" id="search-input" name="q" type="text" placeholder="Search"
+                    aria-label="Search the bakery" autocomplete="off">
                 <div aria-hidden="true" class="navigation__search-icon">
                     <svg width="18" height="18" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg">
-                        <path d="M12.5 11H11.71L11.43 10.73C12.41 9.59 13 8.11 13 6.5C13 2.91 10.09 0 6.5 0C2.91 0 0 2.91 0 6.5C0 10.09 2.91 13 6.5 13C8.11 13 9.59 12.41 10.73 11.43L11 11.71V12.5L16 17.49L17.49 16L12.5 11ZM6.5 11C4.01 11 2 8.99 2 6.5C2 4.01 4.01 2 6.5 2C8.99 2 11 4.01 11 6.5C11 8.99 8.99 11 6.5 11Z" fill="#333333"/>
+                        <path
+                            d="M12.5 11H11.71L11.43 10.73C12.41 9.59 13 8.11 13 6.5C13 2.91 10.09 0 6.5 0C2.91 0 0 2.91 0 6.5C0 10.09 2.91 13 6.5 13C8.11 13 9.59 12.41 10.73 11.43L11 11.71V12.5L16 17.49L17.49 16L12.5 11ZM6.5 11C4.01 11 2 8.99 2 6.5C2 4.01 4.01 2 6.5 2C8.99 2 11 4.01 11 6.5C11 8.99 8.99 11 6.5 11Z"
+                            fill="#333333" />
                     </svg>
                 </div>
             </form>

--- a/bakerydemo/templates/includes/header.html
+++ b/bakerydemo/templates/includes/header.html
@@ -2,33 +2,34 @@
 
 <div class="header clearfix" role="banner">
     <div class="container">
-        <div class="row">
-            <div class="col-lg-12">
-                <a href="/" class="logo">The Wagtail Bakery</a>
-                    <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#main-navigation" aria-label="Mobile menu" aria-expanded="false">
-                        <span class="sr-only">Toggle navigation</span>
-                        <span class="icon-bar"></span>
-                        <span class="icon-bar"></span>
-                        <span class="icon-bar"></span>
-                    </button>
+        <div class="navigation">
+            <a href="/" class="navigation__logo">The Wagtail Bakery</a>
 
-                <form action="/search" method="get" class="search" role="search">
-                    <input name="q" type="text" placeholder="Search the site" aria-label="Search the site" autocomplete="off">
-                    <a href="#" class="search-icon">
-                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 451 451"><path d="M447.05 428l-109.6-109.6c29.4-33.8 47.2-77.9 47.2-126.1C384.65 86.2 298.35 0 192.35 0 86.25 0 .05 86.3.05 192.3s86.3 192.3 192.3 192.3c48.2 0 92.3-17.8 126.1-47.2L428.05 447c2.6 2.6 6.1 4 9.5 4s6.9-1.3 9.5-4c5.2-5.2 5.2-13.8 0-19zM26.95 192.3c0-91.2 74.2-165.3 165.3-165.3 91.2 0 165.3 74.2 165.3 165.3s-74.1 165.4-165.3 165.4c-91.1 0-165.3-74.2-165.3-165.4z"></path></svg>
-                    </a>
-                </form>
+            <button type="button" class="navigation__mobile-toggle navbar-toggle collapsed" data-toggle="collapse" data-target="#main-navigation" aria-label="Mobile menu" aria-expanded="false">
+                <span class="sr-only">Toggle navigation</span>
+                <span class="navigation__toggle-icon-bar"></span>
+                <span class="navigation__toggle-icon-bar"></span>
+                <span class="navigation__toggle-icon-bar"></span>
+            </button>
 
-                {% block main_navigation %}
-                    <nav class="collapse navbar-collapse" id="main-navigation" role="navigation" aria-label="Primary site navigation">
-                        <ul class="nav nav-pills">
-                            {# main_menu is defined in base/templatetags/navigation_tags.py #}
-                            {% get_site_root as site_root %}
-                            {% top_menu parent=site_root calling_page=self %}
-                        </ul>
-                    </nav>
-                {% endblock %}
-            </div>
+            {% block main_navigation %}
+                <nav class="collapse navbar-collapse" id="main-navigation" role="navigation" aria-label="Primary site navigation">
+                    <ul class="navigation__items nav-pills">
+                        {# main_menu is defined in base/templatetags/navigation_tags.py #}
+                        {% get_site_root as site_root %}
+                        {% top_menu parent=site_root calling_page=self %}
+                    </ul>
+                </nav>
+            {% endblock %}
+
+            <form action="/search" method="get" class="navigation__search" role="search">
+                <input class="navigation__search-input" name="q" type="text" placeholder="Search" aria-label="Search the bakery" autocomplete="off">
+                <div aria-hidden="true" class="navigation__search-icon">
+                    <svg width="18" height="18" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg">
+                        <path d="M12.5 11H11.71L11.43 10.73C12.41 9.59 13 8.11 13 6.5C13 2.91 10.09 0 6.5 0C2.91 0 0 2.91 0 6.5C0 10.09 2.91 13 6.5 13C8.11 13 9.59 12.41 10.73 11.43L11 11.71V12.5L16 17.49L17.49 16L12.5 11ZM6.5 11C4.01 11 2 8.99 2 6.5C2 4.01 4.01 2 6.5 2C8.99 2 11 4.01 11 6.5C11 8.99 8.99 11 6.5 11Z" fill="#333333"/>
+                    </svg>
+                </div>
+            </form>
         </div>
     </div>
 </div>

--- a/bakerydemo/templates/tags/breadcrumbs.html
+++ b/bakerydemo/templates/tags/breadcrumbs.html
@@ -8,14 +8,14 @@
             {% if ancestors %}
               <ol class="breadcrumb">
 
-                <li><a href="/"><i class="fa fa-home" aria-hidden="true"></i><span class="hidden" aria-hidden="false">Home</span></a></li>
+                <li><a href="/">Home</a> {% include "includes/chevron-icon.html" with class="breadcrumb__chevron-icon" %}</li>
                   {% for ancestor in ancestors|slice:"1:" %}
                     {% if forloop.last %}
                       <li class="active" aria-level="{{ancestors|length}}">
                         {{ ancestor }}
                       </li>
                     {% else %}
-                      <li><a href="{% pageurl ancestor %}" aria-level="{% cycle 1 2 3 4 5 %}">{{ ancestor }}</a></li>  
+                      <li><a href="{% pageurl ancestor %}" aria-level="{% cycle 1 2 3 4 5 %}">{{ ancestor }}</a> {% include "includes/chevron-icon.html" with class="breadcrumbs__chevron-icon" %}</li>  
                     {% endif %}
                   {% endfor %}
               </ol>


### PR DESCRIPTION
#### [View changes on GitPod](https://gitpod.io/#https://github.com/jhancock532/bakerydemo/tree/restyle-header-and-footer)

I've added the new header navigation in this MR - note that the CSS for this involves overriding some of Bootstrap's default nav styles, so it's a little involved in parts. I've also added the breadcrumb styles in this MR, as these are close to the header & don't have a seperate ticket.

<details><summary>Screenshots</summary>
<img width="1440" alt="Screenshot 2022-05-03 at 16 30 41" src="https://user-images.githubusercontent.com/18164832/166485519-7f3302a1-5a17-459a-b8f9-98ba09248ddc.png">

<img width="499" alt="Screenshot 2022-05-03 at 16 30 55" src="https://user-images.githubusercontent.com/18164832/166485494-9391a26b-2989-4db4-ae7b-23cbedad0ff8.png">

<img width="497" alt="Screenshot 2022-05-03 at 16 31 23" src="https://user-images.githubusercontent.com/18164832/166485461-cae00ed3-2366-41be-adba-b3b2cf124b78.png">

<img width="1440" alt="Screenshot 2022-05-03 at 16 30 41" src="https://user-images.githubusercontent.com/18164832/166485581-2719d81f-0278-4cb4-9724-77e8f8a973d3.png">
</details>