### PR TITLE
Restyle Footer

### DIFF
--- a/bakerydemo/static/css/main.css
+++ b/bakerydemo/static/css/main.css
@@ -542,8 +542,6 @@ hr {
 }
 
 footer {
-  font-size: 16px;
-  font-family: var(--font--secondary);
   padding: 55px 0 30px 0;
   background-color: var(--white);
 }
@@ -563,6 +561,20 @@ footer {
 
 .footer__icon:hover .fa-inverse {
   color: var(--cream);
+}
+
+.copyright p {
+  color: var(--dark);
+  font-family: var(--font--secondary);
+  font-size: 16px;
+  line-height: 24px;
+}
+
+@media (min-width: 768px) {
+  .copyright p {
+    font-size: 18px;
+    line-height: 28px;
+  }
 }
 
 .container {

--- a/bakerydemo/static/css/main.css
+++ b/bakerydemo/static/css/main.css
@@ -535,22 +535,34 @@ li.has-submenu a.allow-toggle {
 }
 
 /* Custom page footer */
-.footer {
-  padding-top: 19px;
-  color: #777;
+hr {
+  margin: 0;
+  border-top: 1px solid var(--light-brown);
+  opacity: 0.25;
 }
 
-.footer {
+footer {
   font-size: 16px;
   font-family: var(--font--secondary);
-  padding: 20px 0;
-  margin: 40px 0 0;
-  font-weight: 300;
-  background-color: white;
+  padding: 55px 0 30px 0;
+  background-color: var(--white);
 }
 
-.footer p {
-  margin: 0;
+.footer__icon a {
+  color: var(--cream);
+  font-size: 24px;
+}
+
+.footer__icon .fa-inverse {
+  color: var(--orange);
+}
+
+.footer__icon:hover a {
+  color: var(--orange);
+}
+
+.footer__icon:hover .fa-inverse {
+  color: var(--cream);
 }
 
 .container {

--- a/bakerydemo/templates/base/include/footer_text.html
+++ b/bakerydemo/templates/base/include/footer_text.html
@@ -1,5 +1,5 @@
 {% load wagtailcore_tags %}
 
-<div class="copyright text-center text-muted" role="note">
+<div class="copyright" role="note">
     {{ footer_text|richtext }}
 </div>

--- a/bakerydemo/templates/includes/footer.html
+++ b/bakerydemo/templates/includes/footer.html
@@ -2,26 +2,26 @@
 
 <div class="container" role="contentinfo">
     <div class="row">
-        <div class="col-lg-8 col-lg-offset-2 col-md-10 col-md-offset-1">
-            <ul class="list-inline text-center">
-                <li>
-                    <a href="https://github.com/wagtail/wagtail">
+        <div class="col-sm-12">
+            <ul class="list-inline">
+                <li class="footer__icon">
+                    <a href="https://github.com/wagtail/wagtail" target="_blank" aria-label="View Wagtail's source code on GitHub">
                         <span class="fa-stack fa-lg">
                             <i class="fa fa-circle fa-stack-2x"></i>
                             <i class="fa fa-github fa-stack-1x fa-inverse"></i>
                         </span>
                     </a>
                 </li>
-                <li>
-                    <a href="https://twitter.com/wagtailcms" target="_blank">
+                <li class="footer__icon">
+                    <a href="https://twitter.com/wagtailcms" target="_blank" aria-label="Wagtail's official Twitter account">
                         <span class="fa-stack fa-lg">
                             <i class="fa fa-circle fa-stack-2x"></i>
                             <i class="fa fa-twitter fa-stack-1x fa-inverse"></i>
                         </span>
                     </a>
                 </li>
-                <li>
-                    <a href="https://wagtail.org/" target="_blank">
+                <li class="footer__icon">
+                    <a href="https://wagtail.org/" target="_blank" aria-label="Wagtail's official website">
                         <span class="fa-stack fa-lg">
                             <i class="fa fa-circle fa-stack-2x"></i>
                             <i class="fa fa-link fa-stack-1x fa-inverse"></i>


### PR DESCRIPTION
### [Open Environment in GitPod](https://gitpod.io/#https://github.com/jhancock532/bakerydemo/tree/restyle-footer)

I've made a simpler footer design as otherwise this ticket requires backend refactoring to split the copyright text and the quote text. I've changed the font colour to dark for better accessibility, and aligned the social media icons to the left to pair with the footer text.

<details><summary>Screenshots</summary>
<img width="722" alt="image" src="https://user-images.githubusercontent.com/18164832/166656954-13b42b20-ba48-4ba9-92b3-c8f8d4ed9a2b.png">

<img width="568" alt="image" src="https://user-images.githubusercontent.com/18164832/166657016-2cd1150d-0c60-42dd-92b2-638adfbe9229.png">
</details>