### PR TITLE
Restyle Blog Listing Page

### DIFF
--- a/bakerydemo/static/css/main.css
+++ b/bakerydemo/static/css/main.css
@@ -314,7 +314,6 @@ cite {
 }
 
 /* Page header */
-
 .header {
   padding: 15px 0 15px;
   width: 100%;
@@ -331,6 +330,39 @@ cite {
   margin-top: 0;
   margin-bottom: 0;
   line-height: 40px;
+}
+
+.index-header__title {
+  color: var(--dark);
+  font-weight: 400;
+  font-size: 46px;
+  line-height: 50px;
+  margin-top: 30px;
+}
+
+.index-header__introduction {
+  color: var(--dark);
+  font-family: var(--font--primary);
+  font-weight: 400;
+  font-size: 26px;
+  line-height: 30px;
+  margin-top: 20px;
+  margin-bottom: 60px;
+}
+
+@media (min-width: 766px) {
+  .index-header__title {
+    font-size: 100px;
+    line-height: 64px;
+    margin-top: 70px;
+  }
+  
+  .index-header__introduction {
+    font-size: 32px;
+    line-height: 42px;
+    margin-top: 40px;
+    margin-bottom: 40px;
+  }
 }
 
 /* Logo */
@@ -695,39 +727,38 @@ time.location-time {
   z-index: 1;
 }
 
-/* Blog list view */
-.blog-tags > li {
-  border-right: 1px solid rgba(0, 0, 0, 0.1);
-  font-size: 0.9em;
-  margin-left: -6px;
-  padding: 4px 18px;
-  text-transform: uppercase;
-}
-
-.blog-tags > li:first-child {
-  margin-left: 0;
-  border-left: 1px solid rgba(0, 0, 0, 0.1);
-}
-
-.blog-tags > li:hover {
-  background-color: rgba(0, 0, 0, 0.1);
-}
-
-.blog-list li {
+/* ---- Blog Index Page ---- */
+.blog-tags {
   list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  padding-left: 0;
+  row-gap: 25px;
+  column-gap: 15px;
+  margin-bottom: 70px;
 }
 
-@media (min-width: 1025px) {
-  .blog-list li:first-of-type,
-  .blogpage-listing li:first-of-type,
-  .blog-list li:nth-child(6),
-  .blogpage-listing li:nth-child(6),
-  .blog-list li:nth-child(7),
-  .blogpage-listing li:nth-child(7),
-  .blog-list li:nth-child(12),
-  .blogpage-listing li:nth-child(12) {
-    width: 50%;
-  }
+.blog-tags__pill {
+  padding: 10px 18px;
+  font-size: 18px;
+  line-height: 28px;
+  border: 1px solid var(--orange);
+  border-radius: 60px;
+  margin-left: 20px;
+  text-transform: capitalize;
+}
+
+.blog-tags__pill:first-child {
+  margin-left: 0;
+}
+
+.blog-tags__pill:hover {
+  background-color: var(--orange);
+  color: var(--white);
+}
+
+.blog-list {
+  padding: 0;
 }
 
 .blog-list-item {
@@ -794,11 +825,12 @@ time.location-time {
 
 /* used to style tags on blog */
 span.outline {
+  color: var(--dark-orange);
   border-radius: 3px;
-  border: 1px solid rgba(0, 0, 0, 0.1);
-  font-size: 0.8em;
+  border: 1px solid var(--dark-orange);
   padding: 3px 6px;
-  text-transform: uppercase;
+  text-transform: capitalize;
+  margin-left: 5px;
 }
 
 /* Blog detail page */
@@ -1371,7 +1403,7 @@ input[type="radio"] {
 /* #endregion */
 
 /* #region ---- Listing Card ---- */
-.listing-card {
+.blog-listing-card {
   padding-bottom: 40px;
 }
 
@@ -1427,6 +1459,104 @@ input[type="radio"] {
     margin: 0;
     max-width: 180px;
     max-height: 180px;
+  }
+}
+
+/* #endregion */
+
+/* #region ---- Blog Listing Card ---- */
+.blog-listing-card {
+  padding-bottom: 40px;
+  width: 100%;
+}
+
+.blog-listing-card:last-child {
+  padding-bottom: 100px;
+}
+
+.blog-listing-card__link {
+  display: flex;
+  flex-direction: column;
+  padding-bottom: 30px;
+  border-bottom: 1px solid rgba(135, 116, 79, 0.25);
+}
+
+.blog-listing-card__contents {
+  padding-top: 10px;
+}
+
+.blog-listing-card__title {
+  font-size: 26px;
+  line-height: 30px;
+  color: var(--orange);
+  margin-top: 0;
+  margin-bottom: 8px;
+}
+
+.blog-listing-card__introduction {
+  font-size: 16px;
+  line-height: 24px;
+  color: var(--dark);
+  margin-bottom: 8px;
+  max-width: 530px;
+}
+
+.blog-listing-card__metadata {
+  font-size: 14px;
+  line-height: 20px;
+  color: var(--grey);
+  margin-bottom: 0;
+}
+
+.blog-listing-card__image {
+  width: 100%;
+  overflow: hidden;
+  margin: 0;
+}
+
+.blog-listing-card__image img {
+  transition: transform ease 0.2s;
+}
+
+.blog-listing-card:hover .blog-listing-card__image img {
+  transform: scale(1.05);
+}
+
+.blog-listing-card:hover .blog-listing-card__title {
+  color: var(--dark-orange);
+  text-decoration: underline;
+}
+
+@media (min-width: 766px){
+  .blog-listing-card:last-child {
+    padding-bottom: 200px;
+  }
+
+  .blog-listing-card__link {
+    flex-direction: row;
+  }
+
+  .blog-listing-card__contents {
+    padding-top: 30px;
+    padding-left: 45px;
+  }
+
+  .blog-listing-card__title {
+    font-size: 32px;
+    line-height: 42px;
+  }
+
+  .blog-listing-card__introduction {
+    font-size: 18px;
+    line-height: 28px;
+  }
+
+  .blog-listing-card__image {
+    flex-shrink: 0;
+    overflow: hidden;
+    margin: 0;
+    width: 325px;
+    height: 250px;
   }
 }
 

--- a/bakerydemo/static/css/main.css
+++ b/bakerydemo/static/css/main.css
@@ -757,6 +757,11 @@ time.location-time {
   color: var(--white);
 }
 
+.blog-tags__tag {
+  color: var(--orange);
+  text-transform: capitalize;
+}
+
 .blog-list {
   padding: 0;
 }
@@ -821,16 +826,6 @@ time.location-time {
   padding: 20px;
   position: relative;
   z-index: 1;
-}
-
-/* used to style tags on blog */
-span.outline {
-  color: var(--dark-orange);
-  border-radius: 3px;
-  border: 1px solid var(--dark-orange);
-  padding: 3px 6px;
-  text-transform: capitalize;
-  margin-left: 5px;
 }
 
 /* Blog detail page */

--- a/bakerydemo/templates/base/include/header-index.html
+++ b/bakerydemo/templates/base/include/header-index.html
@@ -3,8 +3,10 @@
 <div class="container">
     <div class="row">
         <div class="col-md-12">
-            <h1>{{ page.title }}</h1>
-            <p>{{ page.introduction }}</p>
+            <h1 class="index-header__title">{{ page.title }}</h1>
+        </div>
+        <div class="col-sm-12 col-md-7">
+            <p class="index-header__introduction">{{ page.introduction }}</p>
         </div>
     </div>
 </div>

--- a/bakerydemo/templates/base/include/header-index.html
+++ b/bakerydemo/templates/base/include/header-index.html
@@ -6,7 +6,9 @@
             <h1 class="index-header__title">{{ page.title }}</h1>
         </div>
         <div class="col-sm-12 col-md-7">
-            <p class="index-header__introduction">{{ page.introduction }}</p>
+            {% if page.introduction %}
+                <p class="index-header__introduction">{{ page.introduction }}</p>
+            {% endif %}
         </div>
     </div>
 </div>

--- a/bakerydemo/templates/blog/blog_index_page.html
+++ b/bakerydemo/templates/blog/blog_index_page.html
@@ -2,13 +2,18 @@
 {% load wagtailcore_tags navigation_tags wagtailimages_tags %}
 
 {% block content %}
-    {% include "base/include/header-index.html" %}
+    {% if not tag %}
+        {% include "base/include/header-index.html" %}
+    {% endif %}
 
     <div class="container">
         {% if tag %}
             <div class="row">
                 <div class="col-md-12">
-                    <p>Viewing all blog posts sorted by the tag <span class="outline">{{ tag }}</span></p>
+                    <h1 class="index-header__title">Blog</h1>
+                </div>
+                <div class="col-md-12">
+                    <p class="index-header__introduction">Viewing all blog posts sorted by the tag <span class="blog-tags__tag">{{ tag }}</span>.</p>
                 </div>
             </div>
         {% endif %}

--- a/bakerydemo/templates/blog/blog_index_page.html
+++ b/bakerydemo/templates/blog/blog_index_page.html
@@ -21,7 +21,7 @@
         {% if page.get_child_tags %}
             <ul class="blog-tags">
                 {% for tag in page.get_child_tags %}
-                    <li><a class="blog-tags__pill" href="{{ tag.url }}">{{ tag }}</a></li>
+                    <li><a class="blog-tags__pill" aria-label="Filter by tag name {{ tag }}" href="{{ tag.url }}">{{ tag }}</a></li>
                 {% endfor %}
             </ul>
         {% endif %}

--- a/bakerydemo/templates/blog/blog_index_page.html
+++ b/bakerydemo/templates/blog/blog_index_page.html
@@ -8,42 +8,23 @@
         {% if tag %}
             <div class="row">
                 <div class="col-md-12">
-                    <p>Viewing all blog posts by <span class="outline">{{ tag }}</span></p>
+                    <p>Viewing all blog posts sorted by the tag <span class="outline">{{ tag }}</span></p>
                 </div>
             </div>
         {% endif %}
 
         {% if page.get_child_tags %}
-            <ul class="blog-tags tags list-inline">
+            <ul class="blog-tags">
                 {% for tag in page.get_child_tags %}
-                    <li><a href="{{ tag.url }}">{{ tag }}</a></li>
+                    <li><a class="blog-tags__pill" href="{{ tag.url }}">{{ tag }}</a></li>
                 {% endfor %}
             </ul>
         {% endif %}
 
-        <div class="row row-eq-height blog-list">
+        <div class="blog-list">
             {% if posts %}
                 {% for blog in posts %}
-                    <li class="col-xs-12 col-sm-6 col-md-3 blog-list-item">
-                        <a href="{% pageurl blog %}">
-                            <div class="image">
-                                {% image blog.image fill-850x450-c50 as image %}
-                                <img src="{{ image.url }}" width="{{ image.width }}" height="{{ image.height }}" alt="{{ image.alt }}" class="" />
-                            </div>
-                            <div class="text">
-                                <h2 class="blog-list-title">{{ blog.title }}</h2>
-                                <p>{{ blog.introduction|truncatewords:15 }}</p>
-                            </div>
-                            <div class="small footer">
-                                {% if blog.date_published %}
-                                    {{ blog.date_published }} by 
-                                {% endif %}
-                                {% for author in blog.authors %}
-                                    {{ author }}{% if not forloop.last %}, {% endif %}
-                                {% endfor %}
-                            </div>
-                        </a>
-                    </li>
+                    {% include "includes/card/blog-listing-card.html" %}
                 {% endfor %}
             {% else %}
                 <div class="col-md-12">

--- a/bakerydemo/templates/includes/card/blog-listing-card.html
+++ b/bakerydemo/templates/includes/card/blog-listing-card.html
@@ -1,0 +1,26 @@
+{% load wagtailcore_tags navigation_tags wagtailimages_tags %}
+
+<div class="blog-listing-card">
+    <a class="blog-listing-card__link" href="{% pageurl blog %}">
+        <figure class="blog-listing-card__image">
+            {% image blog.image fill-322x247-c100 %}
+        </figure>
+        <div class="blog-listing-card__contents">
+            <h2 class="blog-listing-card__title">{{ blog.title }}</h2>
+            {% if blog.introduction %}
+                <p class="blog-listing-card__introduction">{{ blog.introduction|truncatewords:15 }}</p>
+            {% endif %}
+            <p class="blog-listing-card__metadata">
+                {% if blog.date_published %}
+                    {{ blog.date_published }} by 
+                {% endif %}
+                {% for author in blog.authors %}
+                    {{ author }}{% if not forloop.last %}, {% endif %}
+                {% endfor %}
+            </p>
+        </div>
+    </a>
+</div>
+
+
+

--- a/bakerydemo/templates/includes/card/blog-listing-card.html
+++ b/bakerydemo/templates/includes/card/blog-listing-card.html
@@ -2,9 +2,11 @@
 
 <div class="blog-listing-card">
     <a class="blog-listing-card__link" href="{% pageurl blog %}">
-        <figure class="blog-listing-card__image">
-            {% image blog.image fill-322x247-c100 %}
-        </figure>
+        {% if blog.image %}
+            <figure class="blog-listing-card__image">
+                {% image blog.image fill-322x247-c100 %}
+            </figure>
+        {% endif %}
         <div class="blog-listing-card__contents">
             <h2 class="blog-listing-card__title">{{ blog.title }}</h2>
             {% if blog.introduction %}


### PR DESCRIPTION
### [Link to GitPod Dev Environment](https://gitpod.io/#https://github.com/jhancock532/bakerydemo/tree/restyle-blog-listing)

Adds the blog index page, including a custom card component and filter tag styles.
Adds the header index component styles, as used across the site.

<details><summary>Screenshots</summary>

<img width="1438" alt="Screenshot 2022-05-04 at 11 44 14" src="https://user-images.githubusercontent.com/18164832/166667353-3ff9b6bc-6eae-439d-8628-58c3cb39d712.png">

<img width="496" alt="image" src="https://user-images.githubusercontent.com/18164832/166717599-08d468c5-6d0b-4633-91a2-747e02346d4e.png">

Filtered content blog view.

<img width="294" alt="Screenshot 2022-05-04 at 16 33 23" src="https://user-images.githubusercontent.com/18164832/166717454-1778f648-4911-418e-acab-06c0c83c4b8c.png">

<img width="1434" alt="Screenshot 2022-05-04 at 16 33 35" src="https://user-images.githubusercontent.com/18164832/166717427-d63ac080-577a-4165-9c17-182cfa4c11f7.png">

</details>
