### PR TITLE
Restyle Locations Page

### DIFF
--- a/bakerydemo/static/css/main.css
+++ b/bakerydemo/static/css/main.css
@@ -678,47 +678,19 @@ nav[role="pagination"] {
 }
 
 /* Location list page */
-.location-list-item {
-  text-align: center;
-  margin-bottom: 30px;
+.location-list-page {
+  padding: 0 0 70px 0;
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 10px;
 }
 
-.location-list-title {
-  line-height: 270px;
-  height: 270px;
-  background-color: #eb7400;
-}
-
-.location-list-title img {
-  background-color: rgba(233, 228, 221, 1);
-  height: 270px;
-  left: 0;
-  position: absolute;
-  top: 0;
-  width: 100%;
-}
-
-.location-list-title:hover img {
-  opacity: 0.3;
-}
-
-.location-list-title span.title {
-  color: white;
-  display: inline-block;
-  font-weight: 300;
-  position: relative;
-  text-shadow: 0px 0px 30px rgba(0, 0, 0, 1);
-}
-
-.location-list-title:hover span.title {
-  text-shadow: none;
-}
-
-.location-list-item address {
-  font-weight: 300;
-  font-family: var(--font--secondary);
-  font-size: 1.4em;
-  padding: 10px 40px;
+@media (min-width: 766px) {
+  .location-list-page {
+    padding: 50px 0 110px 0;
+    grid-template-columns: 1fr 1fr;
+    gap: 30px;
+  }
 }
 
 /* Location detail page */

--- a/bakerydemo/templates/base/home_page.html
+++ b/bakerydemo/templates/base/home_page.html
@@ -92,7 +92,7 @@
                     <h2 class="blog-section__title">{{ page.featured_section_3_title }}</h2>
                     <div class="blog-section__grid">
                         {% for childpage in page.featured_section_3.specific.children|slice:"6" %}
-                            {% include "includes/card/picture-card.html" %}
+                            {% include "includes/card/picture-card.html" with page=childpage portrait=True %}
                         {% endfor %}
                     </div>
                 </div>

--- a/bakerydemo/templates/includes/card/picture-card.html
+++ b/bakerydemo/templates/includes/card/picture-card.html
@@ -1,11 +1,15 @@
 {% load wagtailimages_tags %}
 
 <div class="picture-card">
-    <a class="picture-card__link" href="{{ childpage.url }}">
+    <a class="picture-card__link" href="{{ page.url }}">
         <figure class="picture-card__image">
-            {% image childpage.image fill-433x487-c100 %}
+            {% if portrait %}
+                {% image page.image fill-433x487-c100 %}
+            {% else %}
+                {% image page.image fill-645x480-c75 %}
+            {% endif %}
             <div class="picture-card__contents">
-                <h3 class="picture-card__title">{{ childpage.title }}</h3>
+                <h3 class="picture-card__title">{{ page.title }}</h3>
             </div>
         </figure>
     </a>

--- a/bakerydemo/templates/locations/locations_index_page.html
+++ b/bakerydemo/templates/locations/locations_index_page.html
@@ -2,32 +2,15 @@
 {% load wagtailcore_tags navigation_tags wagtailimages_tags %}
 
 {% block content %}
-<div class="container">
-    <div class="row">
-        <div class="col-md-12">
-            <h1>{{ page.title }}</h1>
-            <p>{{ page.introduction }}</p>
-        </div>
-    </div>
-</div>
+
+{% include "base/include/header-index.html" %}
 
 <div class="container">
-    <div class="row no-gutters">
+    <div class="location-list-page">
         {% for location in locations %}
-            <div class="col-md-6 location-list-item">
-                <a href="{% pageurl location %}">
-                <h1 class="location-list-title">
-
-                    {% image location.image fill-660x270-c75 as image %}
-                    <img src="{{ image.url }}" width="{{ image.width }}" height="{{ image.height }}" alt="{{ image.alt }}" class="" />
-
-                    <span class="title">{{ location.title }}</span>
-
-                </h1></a>
-                    <address>{{ location.address }}</address>
-                    <a href="https://google.com/maps/?q={{ location.lat_long }}" class="btn" target="_blank">Map</a>
-            </div>
+            {% include "includes/card/picture-card.html" with page=location portrait=False %}
         {% endfor %}
     </div>
 </div>
 {% endblock content %}
+


### PR DESCRIPTION
### [Link to GitPod Instance](https://gitpod.io/#https://github.com/jhancock532/bakerydemo/tree/restyle-locations-page)

Refactors the picture card to support portrait and landscape images. I'm not sure if this form of templating is standard practice, would we normally allow the user to pass in width / height values for picture cards instead?

Restyles the location page according [to the designs](https://www.figma.com/file/pQXoIKqxSK4QmOAEadeSkd/Wagtail-Bakery?node-id=0%3A1). 

### Screenshots
<details><summary>Expand to view more</summary>

![8080-jhancock532-bakerydemo-vmwvwdz6bqh ws-eu44 gitpod io_locations_(iPhone SE)](https://user-images.githubusercontent.com/18164832/166939094-b928df76-a69b-4e84-9a36-482b42bd15fc.png)

![8080-jhancock532-bakerydemo-vmwvwdz6bqh ws-eu44 gitpod io_locations_](https://user-images.githubusercontent.com/18164832/166939104-e8070a16-baa2-4fa3-b269-7a046de66821.png)

<a href="#">Back to top</a>
</details>

### Checklist

- [x] Add a description of your pull request and instructions for the reviewer to verify your work.
- [x] Stay on point and keep it small so the merge request can be easily reviewed.
- [x] Consider updating documentation. If you don't, tell us why.
- [x] If relevant, list the environments / browsers in which you tested your changes.