### PR TITLE
Restyle Search Page

### DIFF
--- a/bakerydemo/static/css/main.css
+++ b/bakerydemo/static/css/main.css
@@ -861,6 +861,33 @@ footer {
   background-color: var(--dark-orange);
 }
 
+/* Search page */
+.search__introduction {
+  color: var(--dark);
+  font-family: var(--font--primary);
+  font-weight: 400;
+  font-size: 2.6rem;
+  line-height: 1.15;
+  margin-top: 20px;
+  margin-bottom: 40px;
+}
+
+.search__results {
+  list-style-type: none;
+  padding-left: 0;
+  margin-bottom: 90px;
+}
+
+@media (min-width: 768px) {
+  .search__introduction {
+    margin-bottom: 60px;
+  }
+
+  .search__results {
+    margin-bottom: 120px;
+  }
+}
+
 /* Location list page */
 .location-list-page {
   padding: 0 0 70px 0;
@@ -1745,10 +1772,6 @@ input[type="radio"] {
 .listing-card__meta {
   border-collapse: separate;
   border-spacing: 5px;
-}
-
-.listing-card:last-child {
-  margin-bottom: 0;
 }
 
 .listing-card__link {

--- a/bakerydemo/templates/base/home_page.html
+++ b/bakerydemo/templates/base/home_page.html
@@ -31,7 +31,9 @@
                 <h2 class="featured-cards__title">{{ page.featured_section_1_title }}</h2>
                 <ul class="featured-cards__list">
                     {% for childpage in page.featured_section_1.specific.children|slice:"3" %}
-                    {% include "includes/card/listing-card.html" with page=childpage %}
+                    <li>
+                        {% include "includes/card/listing-card.html" with page=childpage %}
+                    </li>
                     {% endfor %}
                 </ul>
                 <a class="featured-cards__link" href="/breads">

--- a/bakerydemo/templates/breads/breads_index_page.html
+++ b/bakerydemo/templates/breads/breads_index_page.html
@@ -7,7 +7,9 @@
     <div class="container">
         <ul class="bread-list">
             {% for bread in breads %}
-                {% include "includes/card/listing-card.html" with page=bread %}
+                <li>
+                    {% include "includes/card/listing-card.html" with page=bread %}
+                </li>
             {% endfor %}
         </ul>
     </div>

--- a/bakerydemo/templates/includes/card/listing-card.html
+++ b/bakerydemo/templates/includes/card/listing-card.html
@@ -1,6 +1,6 @@
 {% load wagtailimages_tags %}
 
-<li class="listing-card">
+<div class="listing-card">
     <a class="listing-card__link" href="{{ page.url }}">
         {% if page.image %}
             <figure class="listing-card__image">
@@ -27,4 +27,4 @@
             {% endif %}
         </div>
     </a>
-</li>
+</div>

--- a/bakerydemo/templates/search/search_results.html
+++ b/bakerydemo/templates/search/search_results.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load wagtailcore_tags %}
+{% load wagtailcore_tags wagtailimages_tags %}
 
 {% block title %}Search{% if search_results %} results{% endif %}{% endblock %}
 
@@ -7,33 +7,41 @@
 <div class="container">
     <div class="row">
         <div class="col-md-8">
-            <h1>
-                Search results
-            </h1>
-
+            <h1>Search results</h1>
             {% if search_results %}
-                <p>You searched{% if search_query %} for “{{ search_query }}”{% endif %}</p>
-                <ul>
+                <p class="search__introduction">You searched{% if search_query %} for “{{ search_query }}”{% endif %}, {{ search_results|length }} results found.</p>
+                <ul class="search__results">
                     {% for result in search_results %}
-                        <li>
-                            <h4>
-                                {% if result.specific.content_type.model == "blogpage" %}
-                                    Blog post:
-                                {% elif result.specific.content_type.model == "locationpage" %}
-                                    Location:
-                                {% else %}
-                                    Bread
+                        <li class="listing-card">
+                            <a class="listing-card__link" href="{% pageurl result.specific %}">
+                                {% if result.specific.image %}
+                                    <figure class="listing-card__image">
+                                        {% image result.specific.image fill-180x180-c100 %}
+                                    </figure>
                                 {% endif %}
-                                <a href="{% pageurl result.specific %}">{{ result.specific }}</a>
-                            </h4>
-                                {% if result.specific.search_description %}{{ result.specific.search_description|safe }}{% endif %}
+                                <div class="listing-card__contents">
+                                    <h3 class="listing-card__title">{{ result.specific }}</h3>
+                                    <p class="listing-card__content-type">
+                                        {% if result.specific.content_type.model == "blogpage" %}
+                                            Blog Post
+                                        {% elif result.specific.content_type.model == "locationpage" %}
+                                            Location
+                                        {% else %}
+                                            Bread
+                                        {% endif %}
+                                    </p>
+                                    <p class="listing-card__description">
+                                        {% if result.specific.search_description %}{{ result.specific.search_description|safe }}{% endif %}
+                                    </p>
+                                </div>
+                            </a>
                         </li>
                     {% endfor %}
                 </ul>
             {% elif search_query %}
-                No results found
+                <p class="search__introduction">No results found for “{{ search_query }}”.</p>
             {% else %}
-                You didn’t search for anything!
+                <p class="search__introduction">You didn&apos;t search for anything!</p>
             {% endif %}
         </div>
     </div>


### PR DESCRIPTION
### [Link to GitPod Instance](https://gitpod.io/#https://github.com/jhancock532/bakerydemo/tree/restyle-search-page)

No ticket for this one - adds styles similar to site theming to the search page, reusing the `listing-card` style rules.

Updates the `listing-card` template to make it more generic, as per Thibaud's suggestion.

### Screenshots
<details><summary>Expand to view more</summary>
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/18164832/170065877-1ff1f784-5f49-44db-a7e7-d3f06ad68b82.png">
<img width="497" alt="image" src="https://user-images.githubusercontent.com/18164832/170065950-75a1e968-f252-436b-bca5-759d5ef03246.png">
<a href="#">Back to top</a>
</details>

### Checklist

- [ ] Add a description of your pull request and instructions for the reviewer to verify your work.
- [ ] Stay on point and keep it small so the merge request can be easily reviewed.
- [ ] Consider updating documentation. If you don't, tell us why.
- [ ] If relevant, list the environments / browsers in which you tested your changes.