### PR TITLE
Restyle Pagination

### DIFF
--- a/bakerydemo/static/css/main.css
+++ b/bakerydemo/static/css/main.css
@@ -847,18 +847,31 @@ footer {
 /* Pagination navigation */
 .pagination {
   display: block;
-  margin-top: 0;
-  text-align: center;
-  margin-bottom: 40px;
+  margin: 0 auto 40px auto;
 }
 
-.pagination .page-item {
+.pagination__list {
+  display: flex;
+  width: 100%;
+  justify-content: center;
+  gap: 20px;
+  list-style-type: none;
+  padding-left: 0;
+}
+
+.pagination .page-item a {
   text-transform: capitalize;
+  text-decoration: underline;
 }
 
-.pagination .active span,
-.pagination .active span:hover {
-  background-color: var(--dark-orange);
+.pagination .page-item.active span {
+  color: var(--grey);
+}
+
+.pagination .page-item.disabled a {
+  color: var(--grey);
+  text-decoration: none;
+  cursor: default;
 }
 
 /* Location list page */

--- a/bakerydemo/templates/includes/pagination.html
+++ b/bakerydemo/templates/includes/pagination.html
@@ -1,7 +1,7 @@
 {% load navigation_tags %}
 
 <nav class="pagination" aria-label="Pagination">
-    <ul>
+    <ul class="pagination__list">
         {% if subpages.has_previous %}
             <li class="page-item">
                 <a href="?page={{ subpages.previous_page_number }}" class="page-link previous arrows">previous</a>
@@ -14,7 +14,7 @@
 
         {% for i in subpages.paginator.page_range %}
             {% if subpages.number == i %}
-              <li class="active"><span>{{ i }} <span class="sr-only">(current)</span></span></li>
+              <li class="page-item active"><span>{{ i }} <span class="sr-only">(current)</span></span></li>
             {% else %}
               <li class="page-item"><a href="?page={{ query_string|urlencode }}&amp;page={{ i }}" class="page-link">{{ i }}</a></li>
             {% endif %}


### PR DESCRIPTION
### [Link to GitPod Instance](https://gitpod.io/#https://github.com/jhancock532/bakerydemo/tree/restyle-pagination)

No ticket, this adds basic pagination styling to avoid Bootstrap's default. This can be tested through adding over 12 different bread types and viewing the bread index page.

Design has been improvised here, pending review from Ben.

### Screenshots
<details><summary>Expand to view more</summary>
<img width="1426" alt="image" src="https://user-images.githubusercontent.com/18164832/170066646-142f686d-662f-4454-97dd-37d3def3e028.png">
<img width="749" alt="image" src="https://user-images.githubusercontent.com/18164832/170066997-f1f83df9-7f9c-4369-926e-b6183c869a48.png">

<a href="#">Back to top</a>
</details>

### Checklist

- [ ] Add a description of your pull request and instructions for the reviewer to verify your work.
- [ ] Stay on point and keep it small so the merge request can be easily reviewed.
- [ ] Consider updating documentation. If you don't, tell us why.
- [ ] If relevant, list the environments / browsers in which you tested your changes.