### PR TITLE
Restyle Standard Page

### DIFF
--- a/bakerydemo/templates/base/standard_page.html
+++ b/bakerydemo/templates/base/standard_page.html
@@ -2,12 +2,21 @@
 {% load wagtailimages_tags %}
 
 {% block content %}
-    {% include "base/include/header.html" %}
+    {% include "base/include/header-hero.html" %}
 
-    <div class="container">
+    <div class="container bread-detail">
         <div class="row">
-            <div class="col-md-7">
-                {{ page.body }}
+            <div class="col-md-12">
+                <div class="col-md-7">
+                    <div class="row">
+                        {% if page.introduction %}
+                            <p class="bread-detail__introduction">
+                                {{ page.introduction }}
+                            </p>
+                        {% endif %}
+                        {{ page.body }}
+                    </div>
+                </div>
             </div>
         </div>
     </div>


### PR DESCRIPTION
### [Link to GitPod Instance](https://gitpod.io/#https://github.com/jhancock532/bakerydemo/tree/restyle-standard-page)

Updates the standard page template to use the styles of the bread page without a side navigation / metadata information bar.

### Screenshots
<details><summary>Expand to view more</summary>

<img width="1439" alt="image" src="https://user-images.githubusercontent.com/18164832/170070286-7e4209b6-cc24-4306-9e60-0fa935b55e3e.png">

![image](https://user-images.githubusercontent.com/18164832/170070432-615746b9-9079-4247-b7ae-518c221e0d90.png)


<a href="#">Back to top</a>
</details>

### Checklist

- [ ] Add a description of your pull request and instructions for the reviewer to verify your work.
- [ ] Stay on point and keep it small so the merge request can be easily reviewed.
- [ ] Consider updating documentation. If you don't, tell us why.
- [ ] If relevant, list the environments / browsers in which you tested your changes.

